### PR TITLE
Remove deprecated spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_regex (0.1.1)
+    ruby_regex (0.1.2)
       rake
       test-unit
 
@@ -20,4 +20,4 @@ DEPENDENCIES
   ruby_regex!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/ruby_regex.gemspec
+++ b/ruby_regex.gemspec
@@ -2,13 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name = "ruby_regex"
-  s.version = "0.1.1"
+  s.version = "0.1.2"
   s.author = "Emili Parreno"
   s.email = "emili@eparreno.com"
   s.homepage = "http://github.com/eparreno/ruby_regex"
   s.date = %q{2013-11-13}
   s.description = "Ruby regular expressions library"
-  s.has_rdoc = true
   s.rdoc_options = ["--main", "README"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.5}


### PR DESCRIPTION
# What is that for ❓ 

Very simple deprecation warning removal.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```