### PR TITLE
Remove rubygems deprecation warning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    ruby_regex (0.1.1)
+    ruby_regex (0.1.2)
       rake
       test-unit
 
 GEM
   remote: https://rubygems.org/
   specs:
-    power_assert (1.1.1)
-    rake (12.3.0)
-    test-unit (3.2.7)
+    power_assert (1.1.3)
+    rake (12.3.1)
+    test-unit (3.2.8)
       power_assert
 
 PLATFORMS
@@ -20,4 +20,4 @@ DEPENDENCIES
   ruby_regex!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/ruby_regex.gemspec
+++ b/ruby_regex.gemspec
@@ -2,13 +2,12 @@
 
 Gem::Specification.new do |s|
   s.name = "ruby_regex"
-  s.version = "0.1.1"
+  s.version = "0.1.2"
   s.author = "Emili Parreno"
   s.email = "emili@eparreno.com"
   s.homepage = "http://github.com/eparreno/ruby_regex"
   s.date = %q{2013-11-13}
   s.description = "Ruby regular expressions library"
-  s.has_rdoc = true
   s.rdoc_options = ["--main", "README"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.5}


### PR DESCRIPTION
# What is that about ❓ 

Just a removal of a deprecated option on the gemspec file.

## also...
 - Bump the (minor) version.